### PR TITLE
Add @angular/forms to package.json

### DIFF
--- a/generators/app/templates/root/_package.json
+++ b/generators/app/templates/root/_package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@angular/common": "^2.0.0-rc.4",
     "@angular/compiler": "^2.0.0-rc.4",
-    "@angular/core": "^2.0.0-rc.4",<% if (angularPackages['@angular/http']) { %>
+    "@angular/core": "^2.0.0-rc.4",
+    "@angular/forms": "^0.2.0",<% if (angularPackages['@angular/http']) { %>
     "@angular/http": "^2.0.0-rc.4",<% } %>
     "@angular/platform-browser": "^2.0.0-rc.4",
     "@angular/platform-browser-dynamic": "^2.0.0-rc.4",


### PR DESCRIPTION
In RC3, the forms module is now now a separate package. It stays so with RC4.
Forms are quite essential for Angular2 though, and were for long part of the main packages bundle, so, I thought this doesn't need to be its own `angularPackages()` thing and just added it.

The forms version 0.1.1 matches RC3 and was not included.
The forms version 0.2.0 matches RC4 and this is what's added here.

The reason for the order is that this is how the NPM tool writes it when you say:

```
npm install @angular/forms -S
```

With the rest of stuff already in `package.json`, likely due to alphabetical order.
