### PR TITLE
Force reflect-metadata to 0.1.3

### DIFF
--- a/generators/app/templates/root/_package.json
+++ b/generators/app/templates/root/_package.json
@@ -35,7 +35,7 @@
     "core-js": "^2.4.0",<% if (foundation) { %>
     "foundation-sites": "^6.2.3",<% } %><% if (jquery) { %>
     "jquery": "^2.2.4",<% } %>
-    "reflect-metadata": "^0.1.3",
+    "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },


### PR DESCRIPTION
Fixes reflect-metadata webpack freak out issue, as 0.1.4 is broken in webpack
