### PR TITLE
fix systemjs/gulpfile.js bad option parameter plugin

### DIFF
--- a/generators/app/templates/systemjs/gulpfile.js
+++ b/generators/app/templates/systemjs/gulpfile.js
@@ -74,7 +74,7 @@ gulp.task('tsc', function () {
 
 gulp.task('inline-ng2-templates', function () {
     return gulp.src(['src/**/*.ts'])
-        .pipe(inlineNg2Template({ base: 'src', UseRelativePaths: true, indent: 0, removeLineBreaks: true, templateProcessor: minifyTemplate }))
+        .pipe(inlineNg2Template({ base: 'src', useRelativePaths: true, indent: 0, removeLineBreaks: true, templateProcessor: minifyTemplate }))
         .pipe(tsProject())
         .pipe(gulp.dest(paths.tmp));
 });


### PR DESCRIPTION
I have found a bad declaration of gulp-inline-ng2-template's option parameter.
'UseRelativePaths' must be 'useRelativePaths'.

Fix it.